### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/back/controllers/stripe.js
+++ b/back/controllers/stripe.js
@@ -54,8 +54,14 @@ async function moveFile(src, dest) {
 }
 async function unlinkIfExists(fp) {
   try {
-    const exists = await fs.promises.stat(fp).then(() => true).catch(() => false);
-    if (exists) await fs.promises.unlink(fp);
+    // Ensure the path is inside the TMP_DIR for safety
+    const normalizedPath = path.resolve(fp);
+    if (!normalizedPath.startsWith(TMP_DIR + path.sep)) {
+      console.warn('unlinkIfExists: Attempted to unlink file outside TMP_DIR:', normalizedPath);
+      return;
+    }
+    const exists = await fs.promises.stat(normalizedPath).then(() => true).catch(() => false);
+    if (exists) await fs.promises.unlink(normalizedPath);
   } catch (e) {
     console.warn('unlinkIfExists error:', e?.message || e);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/pertzx/TreinAI/security/code-scanning/20](https://github.com/pertzx/TreinAI/security/code-scanning/20)

To fix the problem, ensure that only files inside a specific, intended directory (such as the temporary upload directory) can be unlinked. Before calling `fs.promises.unlink`, resolve and normalize the path, and check it is within an allowed folder. Specifically:
- Normalize the file path using `path.resolve`.
- Check that the resolved path starts with the expected directory (such as `TMP_DIR`).
- Only call `unlink` if the validation passes; otherwise, do nothing or log a warning.

Since we can see `TMP_DIR` is the intended directory for uploaded files, we will enforce that file deletions only apply to files inside `TMP_DIR`.

In the file `back/controllers/stripe.js`:
- Add a check to `unlinkIfExists`: before attempting to unlink, resolve and verify that the file to be deleted is within `TMP_DIR`.
- Add a conditional: if validation fails, log a warning and do not unlink.

No new dependencies are needed; the required methods (`path.resolve`, `path.join`, etc.) are already available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
